### PR TITLE
Fixed old monty dependency

### DIFF
--- a/pseudo_dojo/core/pseudos.py
+++ b/pseudo_dojo/core/pseudos.py
@@ -10,7 +10,7 @@ from monty.collections import AttrDict
 from monty.string import list_strings
 from monty.fnmatch import WildCard
 from monty.termcolor import cprint
-from monty.os.path import which
+from shutil import which
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.xcfunc import XcFunc
 from abipy.tools.plotting import add_fig_kwargs, get_ax_fig_plt

--- a/pseudo_dojo/core/testing.py
+++ b/pseudo_dojo/core/testing.py
@@ -6,7 +6,7 @@ Common test support for pseudo_dojo.
 This single module should provide all the common functionality for tests
 in a single location, so that test scripts can just import it and work right away.
 """
-from monty.os.path import which
+from shutil import which
 from pymatgen.util.testing import PymatgenTest
 
 import numpy.testing as nptu


### PR DESCRIPTION
## Summary

monty.os.which is deprecated, replaced with shutil.which